### PR TITLE
Remove new() on OperationFilter, ModelFilter and DocumentFilter methods

### DIFF
--- a/src/Swashbuckle/Swagger/SwaggerDocumentOptions.cs
+++ b/src/Swashbuckle/Swagger/SwaggerDocumentOptions.cs
@@ -68,7 +68,7 @@ namespace Swashbuckle.Swagger
         }
 
         public void OperationFilter<TFilter>(TFilter filter)
-            where TFilter : IOperationFilter, new()
+            where TFilter : IOperationFilter
         {
             OperationFilters.Add(filter);
         }
@@ -80,7 +80,7 @@ namespace Swashbuckle.Swagger
         }
 
         public void DocumentFilter<TFilter>(TFilter filter)
-            where TFilter : IDocumentFilter, new()
+            where TFilter : IDocumentFilter
         {
             DocumentFilters.Add(filter);
         }

--- a/src/Swashbuckle/Swagger/SwaggerSchemaOptions.cs
+++ b/src/Swashbuckle/Swagger/SwaggerSchemaOptions.cs
@@ -41,7 +41,7 @@ namespace Swashbuckle.Swagger
         }
 
         public void ModelFilter<TFilter>(TFilter filter)
-            where TFilter : IModelFilter, new()
+            where TFilter : IModelFilter
         {
             ModelFilters.Add(filter);
         }


### PR DESCRIPTION
The OperationFilter, ModelFilter and DocumentFilter methods in the options classes with a IxxxFilter instance as paramater don't need to have a "where : new()." With the "new()", it's impossible to set a ApplyXmlActionComments or ApplyXmlTypeComments filter because these filters don't have a paramtereless constructor.
