### PR TITLE
SwaggerGen : set byte format for properties of type byte[]

### DIFF
--- a/src/Swashbuckle.SwaggerGen/Generator/SchemaRegistry.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SchemaRegistry.cs
@@ -205,6 +205,7 @@ namespace Swashbuckle.SwaggerGen.Generator
             { typeof(double), () => new Schema { Type = "number", Format = "double" } },
             { typeof(decimal), () => new Schema { Type = "number", Format = "double" } },
             { typeof(byte), () => new Schema { Type = "string", Format = "byte" } },
+            { typeof(byte[]), () => new Schema { Type = "string", Format = "byte" } },
             { typeof(sbyte), () => new Schema { Type = "string", Format = "byte" } },
             { typeof(bool), () => new Schema { Type = "boolean" } },
             { typeof(DateTime), () => new Schema { Type = "string", Format = "date-time" } },


### PR DESCRIPTION
When a model contains a byte[] property, the generated schema does not specify the format as byte, and thus, client generator Tools generate a model with a string property.
With this fix, generators like autorest generate byte arrays proxy models and correctly serialize them as base64