### PR TITLE
format "uuid" for System.Guid to allow clients to generate proxies with Guid

### DIFF
--- a/src/Swashbuckle.SwaggerGen/Generator/SchemaRegistry.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SchemaRegistry.cs
@@ -208,7 +208,8 @@ namespace Swashbuckle.SwaggerGen.Generator
             { typeof(sbyte), () => new Schema { Type = "string", Format = "byte" } },
             { typeof(bool), () => new Schema { Type = "boolean" } },
             { typeof(DateTime), () => new Schema { Type = "string", Format = "date-time" } },
-            { typeof(DateTimeOffset), () => new Schema { Type = "string", Format = "date-time" } }
+            { typeof(DateTimeOffset), () => new Schema { Type = "string", Format = "date-time" } },
+            { typeof(Guid), () => new Schema { Type = "string", Format = "uuid" } }
         };
     }
 }

--- a/test/Swashbuckle.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
+++ b/test/Swashbuckle.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
@@ -30,6 +30,7 @@ namespace Swashbuckle.SwaggerGen.Generator
         [InlineData(typeof(DateTime), "string", "date-time")]
         [InlineData(typeof(DateTimeOffset), "string", "date-time")]
         [InlineData(typeof(string), "string", null)]
+        [InlineData(typeof(Guid), "string", "uuid")]
         public void GetOrRegister_ReturnsPrimitiveSchema_ForSimpleTypes(
             Type systemType,
             string expectedType,


### PR DESCRIPTION
Right now, Guid parameters are rendered with type "string" and with no "format". This pull request adds "uuid" for the format field. This allows clients tools to generate it back to Guid. I used "uuid" because that's the example from the specification. "Guid" is just one implementation of uuid. https://en.wikipedia.org/wiki/Globally_unique_identifier

this could also be backported to the older versions ( https://github.com/domaindrivendev/Swashbuckle/issues/527 )
