### PR TITLE
upgrade to asp.net core rc2

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="AspNetCiDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="dotnet-cli" value="https://www.myget.org/F/dotnet-cli/api/v3/index.json" />
+    <add key="aspnet-contrib" value="https://www.myget.org/F/aspnet-contrib/api/v3/index.json" />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
   "sources": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-rc1-final",
-    "runtime": "clr",
+    "version": "1.0.0-rc2-16551",
+    "runtime": "coreclr",
     "architecture": "x86"
   },
   "projects": [ "test/WebSites", "src" ]

--- a/src/Swashbuckle.SwaggerGen/Annotations/XmlCommentsOperationFilter.cs
+++ b/src/Swashbuckle.SwaggerGen/Annotations/XmlCommentsOperationFilter.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
 using System.Xml.XPath;
-using Microsoft.AspNet.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Swashbuckle.SwaggerGen.Generator;
 
 namespace Swashbuckle.SwaggerGen.Annotations

--- a/src/Swashbuckle.SwaggerGen/Application/SwaggerApplicationConvention.cs
+++ b/src/Swashbuckle.SwaggerGen/Application/SwaggerApplicationConvention.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Mvc.ApplicationModels;
+﻿using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
 namespace Swashbuckle.SwaggerGen.Application
 {

--- a/src/Swashbuckle.SwaggerGen/Application/SwaggerGenBuilderExtensions.cs
+++ b/src/Swashbuckle.SwaggerGen/Application/SwaggerGenBuilderExtensions.cs
@@ -2,7 +2,7 @@
 using Swashbuckle.SwaggerGen.Application;
 using Swashbuckle.SwaggerGen.Generator;
 
-namespace Microsoft.AspNet.Builder
+namespace Microsoft.AspNetCore.Builder
 {
     public static class SwaggerGenBuilderExtensions
     {

--- a/src/Swashbuckle.SwaggerGen/Application/SwaggerGenMIddleware.cs
+++ b/src/Swashbuckle.SwaggerGen/Application/SwaggerGenMIddleware.cs
@@ -1,9 +1,8 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Routing;
-using Microsoft.AspNet.Routing.Template;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Template;
 using Newtonsoft.Json;
 using Swashbuckle.SwaggerGen.Generator;
 

--- a/src/Swashbuckle.SwaggerGen/Application/SwaggerGenOptions.cs
+++ b/src/Swashbuckle.SwaggerGen/Application/SwaggerGenOptions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.XPath;
-using Microsoft.AspNet.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Swashbuckle.SwaggerGen.Generator;
 using Swashbuckle.SwaggerGen.Annotations;

--- a/src/Swashbuckle.SwaggerGen/Application/SwaggerGenServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.SwaggerGen/Application/SwaggerGenServiceCollectionExtensions.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.ApiExplorer;
-using Microsoft.Extensions.OptionsModel;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Swashbuckle.SwaggerGen.Application;
 using Swashbuckle.SwaggerGen.Generator;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Swashbuckle.SwaggerGen/Generator/ApiDescriptionExtensions.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/ApiDescriptionExtensions.cs
@@ -3,8 +3,8 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
-using Microsoft.AspNet.Mvc.ApiExplorer;
-using Microsoft.AspNet.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
 
 namespace Swashbuckle.SwaggerGen.Generator
 {
@@ -32,7 +32,7 @@ namespace Swashbuckle.SwaggerGen.Generator
         public static IEnumerable<string> Produces(this ApiDescription apiDescription)
         {
             return apiDescription.SupportedResponseFormats
-                .Select(format => format.MediaType.MediaType)
+                .Select(format => format.MediaType)
                 .Distinct();
         }
 

--- a/src/Swashbuckle.SwaggerGen/Generator/IDocumentFilter.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/IDocumentFilter.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Mvc.ApiExplorer;
+﻿using Microsoft.AspNetCore.Mvc.ApiExplorer;
 
 namespace Swashbuckle.SwaggerGen.Generator
 {

--- a/src/Swashbuckle.SwaggerGen/Generator/IOperationFilter.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/IOperationFilter.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Mvc.ApiExplorer;
+﻿using Microsoft.AspNetCore.Mvc.ApiExplorer;
 
 namespace Swashbuckle.SwaggerGen.Generator
 {

--- a/src/Swashbuckle.SwaggerGen/Generator/JsonContractExtensions.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/JsonContractExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Serialization;
 
 namespace Swashbuckle.SwaggerGen.Generator

--- a/src/Swashbuckle.SwaggerGen/Generator/SwaggerProvider.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SwaggerProvider.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 
 namespace Swashbuckle.SwaggerGen.Generator
 {

--- a/src/Swashbuckle.SwaggerGen/Generator/SwaggerProviderOptions.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SwaggerProviderOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.AspNet.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 
 namespace Swashbuckle.SwaggerGen.Generator
 {

--- a/src/Swashbuckle.SwaggerGen/Swashbuckle.SwaggerGen.xproj
+++ b/src/Swashbuckle.SwaggerGen/Swashbuckle.SwaggerGen.xproj
@@ -15,6 +15,8 @@
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Swashbuckle.SwaggerGen/project.json
+++ b/src/Swashbuckle.SwaggerGen/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "6.0.0-rc1-final",
+  "version": "6.0.0-rc2",
   "description": "Swashbuckle - Swagger Generator for WebApi (AspNet 5.0)",
   "summary": "Swagger Generator component for next generation of Swashbuckle, targeting AspNet 5.0 (vNext)",
   "authors": [ "Richard Morris" ],
@@ -8,15 +8,12 @@
   "licenseUrl": "https://github.com/domaindrivendev/Swashbuckle/LICENSE",
 
   "dependencies": {
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final"
+    "Microsoft.AspNetCore.Mvc.Dnx": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc.ApiExplorer": "1.0.0-*",
+    "Microsoft.NETCore.Platforms": "1.0.1-*"
   },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": {
-      "dependencies": {
-        "System.Xml.XPath": "4.0.0"
-      }
-    }
+    "dnx451": { }
   }
 }

--- a/src/Swashbuckle.SwaggerUi/Application/RedirectMiddleware.cs
+++ b/src/Swashbuckle.SwaggerUi/Application/RedirectMiddleware.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Routing;
-using Microsoft.AspNet.Routing.Template;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Template;
 
 namespace Swashbuckle.Application
 {

--- a/src/Swashbuckle.SwaggerUi/Application/SwaggerUiBuilderExtensions.cs
+++ b/src/Swashbuckle.SwaggerUi/Application/SwaggerUiBuilderExtensions.cs
@@ -1,9 +1,10 @@
 ﻿using System.Reflection;
-using Microsoft.AspNet.FileProviders;
-using Microsoft.AspNet.StaticFiles;
+using Microsoft.AspNetCore.StaticFiles;
 using Swashbuckle.Application;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.FileProviders;
 
-namespace Microsoft.AspNet.Builder
+namespace Microsoft.AspNetCore.Builder
 {
     public static class SwaggerUiBuilderExtensions
     {

--- a/src/Swashbuckle.SwaggerUi/Application/SwaggerUiMIddleware.cs
+++ b/src/Swashbuckle.SwaggerUi/Application/SwaggerUiMIddleware.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Text;
 using System.Linq;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Routing;
-using Microsoft.AspNet.Routing.Template;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Template;
 
 namespace Swashbuckle.Application
 {

--- a/src/Swashbuckle.SwaggerUi/Swashbuckle.SwaggerUi.xproj
+++ b/src/Swashbuckle.SwaggerUi/Swashbuckle.SwaggerUi.xproj
@@ -15,6 +15,8 @@
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Swashbuckle.SwaggerUi/project.json
+++ b/src/Swashbuckle.SwaggerUi/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "6.0.0-rc1-final",
+  "version": "6.0.0-rc2",
   "description": "Swashbuckle - Swagger UI for WebApi (AspNet 5.0)",
   "summary": "Swagger UI component for next generation of Swashbuckle, targeting AspNet 5.0 (vNext)",
   "authors": [ "Richard Morris" ],
@@ -8,15 +8,15 @@
   "licenseUrl": "https://github.com/domaindrivendev/Swashbuckle/LICENSE",
 
   "dependencies": {
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.AspNet.FileProviders.Embedded": "1.0.0-rc1-final"
+    "Microsoft.AspNetCore.Mvc.Dnx": "1.0.0-*",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
+    "Microsoft.Extensions.FileProviders.Embedded": "1.0.0-*",
+    "Microsoft.NETCore.Platforms": "1.0.1-*"
   },
 
   "resource": [ "SwaggerUi", "bower_components/swagger-ui/dist" ],
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "dnx451": { }
   }
 }

--- a/src/Swashbuckle/Swashbuckle.nuspec
+++ b/src/Swashbuckle/Swashbuckle.nuspec
@@ -2,23 +2,19 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Swashbuckle</id>
-    <version>6.0.0-rc1-final</version>
+    <version>6.0.0-rc2</version>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <authors>Richard Morris</authors>
     <owners>Richard Morris</owners>
     <licenseUrl>https://github.com/domaindrivendev/Swashbuckle/LICENSE</licenseUrl>
     <projectUrl>https://github.com/domaindrivendev/Swashbuckle</projectUrl>
-    <description>Swashbuckle - Swagger generator and embedded swagger-ui for WebApi (AspNet 5.0)</description>
-    <summary>Next generation of Swashbuckle, targeting AspNet 5.0 (vNext)</summary>
-    <tags>Swagger Documentation Discovery Help WebApi AspNet vNext</tags>
+    <description>Swashbuckle - Swagger generator and embedded swagger-ui for WebApi (AspCore rc2)</description>
+    <summary>Next generation of Swashbuckle, targeting AspNetCore</summary>
+    <tags>Swagger Documentation Discovery Help WebApi AspNet Core</tags>
     <dependencies>
       <group targetFramework="DNX4.5.1">
-        <dependency id="Swashbuckle.SwaggerGen" version="6.0.0-rc1-final" />
-        <dependency id="Swashbuckle.SwaggerUi" version="6.0.0-rc1-final" />
-      </group>
-      <group targetFramework="DNXCore5.0">
-        <dependency id="Swashbuckle.SwaggerGen" version="6.0.0-rc1-final" />
-        <dependency id="Swashbuckle.SwaggerUi" version="6.0.0-rc1-final" />
+        <dependency id="Swashbuckle.SwaggerGen" version="6.0.0-rc2" />
+        <dependency id="Swashbuckle.SwaggerUi" version="6.0.0-rc2" />
       </group>
     </dependencies>
   </metadata>

--- a/test/WebSites/Basic/Controllers/JsonAnnotationsController.cs
+++ b/test/WebSites/Basic/Controllers/JsonAnnotationsController.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/test/WebSites/Basic/Controllers/SwaggerAnnotatedController.cs
+++ b/test/WebSites/Basic/Controllers/SwaggerAnnotatedController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.SwaggerGen.Annotations;
 using Basic.Swagger;
 

--- a/test/WebSites/Basic/Properties/launchSettings.json
+++ b/test/WebSites/Basic/Properties/launchSettings.json
@@ -1,4 +1,12 @@
 {
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:19184/",
+      "sslPort": 0
+    }
+  },
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",

--- a/test/WebSites/Basic/Startup.cs
+++ b/test/WebSites/Basic/Startup.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.PlatformAbstractions;
@@ -14,13 +14,17 @@ namespace Basic
 {
     public class Startup
     {
-        private readonly IApplicationEnvironment _appEnv;
-        private readonly IHostingEnvironment _hostingEnv;
-
-        public Startup(IHostingEnvironment hostingEnv, IApplicationEnvironment appEnv)
+        public static void Main(string[] args)
         {
-            _hostingEnv = hostingEnv;
-            _appEnv = appEnv;
+            var application = new WebHostBuilder()
+               .UseCaptureStartupErrors(captureStartupError: true)
+               .UseDefaultConfiguration(args)
+               .UseIISPlatformHandlerUrl()
+               .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+               .UseStartup<Startup>()
+               .Build();
+
+            application.Run();
         }
 
         // This method gets called by a runtime.
@@ -33,6 +37,8 @@ namespace Basic
                 {
                     options.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
                 });
+
+            services.AddMvcDnx();
 
             // Uncomment the following line to add Web API services which makes it easier to port Web API 2 controllers.
             // You will also need to add the Microsoft.AspNet.Mvc.WebApiCompatShim package to the 'dependencies' section of project.json.
@@ -53,25 +59,25 @@ namespace Basic
                 c.OperationFilter<AssignOperationVendorExtensions>();
             });
 
-            if (_hostingEnv.IsDevelopment())
-            {
-                services.ConfigureSwaggerGen(c =>
-                {
-                    c.IncludeXmlComments(string.Format(@"{0}\artifacts\bin\Basic\{1}\{2}{3}\Basic.xml",
-                        GetSolutionBasePath(),
-                        _appEnv.Configuration,
-                        _appEnv.RuntimeFramework.Identifier,
-                        _appEnv.RuntimeFramework.Version.ToString().Replace(".", string.Empty)));
-                });
-            }
+            //if (_hostingEnv.IsDevelopment())
+            //{
+            //    services.ConfigureSwaggerGen(c =>
+            //    {
+            //        //c.IncludeXmlComments(string.Format(@"{0}\artifacts\bin\Basic\{1}\{2}{3}\Basic.xml",
+            //        //    GetSolutionBasePath(),
+            //        //    _appEnv.Configuration,
+            //        //    _appEnv.RuntimeFramework.Identifier,
+            //        //    _appEnv.RuntimeFramework.Version.ToString().Replace(".", string.Empty)));
+            //    });
+            //}
         }
 
         // Configure is called after ConfigureServices is called.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            loggerFactory.MinimumLevel = LogLevel.Information;
-            loggerFactory.AddConsole();
-            loggerFactory.AddDebug();
+            var factory = app.ApplicationServices.GetRequiredService<ILoggerFactory>();
+            factory.AddConsole();
+            factory.AddDebug();
 
             // Add the platform handler to the request pipeline.
             app.UseIISPlatformHandler();
@@ -89,17 +95,17 @@ namespace Basic
             app.UseSwaggerUi();
         }
 
-        private string GetSolutionBasePath()
-        {
-            var dir = Directory.CreateDirectory(_appEnv.ApplicationBasePath);
-            while (dir.Parent != null)
-            {
-                if (dir.GetFiles("global.json").Any())
-                    return dir.FullName;
+        //private string GetSolutionBasePath()
+        //{
+        //    var dir = Directory.CreateDirectory(_appEnv.ApplicationBasePath);
+        //    while (dir.Parent != null)
+        //    {
+        //        if (dir.GetFiles("global.json").Any())
+        //            return dir.FullName;
 
-                dir = dir.Parent;
-            }
-            throw new InvalidOperationException("Failed to detect solution base path - global.json not found.");
-        }
+        //        dir = dir.Parent;
+        //    }
+        //    throw new InvalidOperationException("Failed to detect solution base path - global.json not found.");
+        //}
     }
 }

--- a/test/WebSites/Basic/project.json
+++ b/test/WebSites/Basic/project.json
@@ -3,25 +3,26 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Diagnostics": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc1-final",
-    "Swashbuckle.SwaggerGen": "6.0.0-rc1-final",
-    "Swashbuckle.SwaggerUi": "6.0.0-rc1-final"
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc.Dnx": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-*",
+    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "Swashbuckle.SwaggerGen": "6.0.0-rc2",
+    "Swashbuckle.SwaggerUi": "6.0.0-rc2"
   },
 
   "commands": {
-    "web": "Microsoft.AspNet.Server.Kestrel"
+    "web": "Microsoft.AspNetCore.Server.Kestrel"
   },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "dnx451": { }
   },
 
   "exclude": [

--- a/test/WebSites/CustomizedUi/Controllers/CrudActionsController.cs
+++ b/test/WebSites/CustomizedUi/Controllers/CrudActionsController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace CustomizedUi.Controllers
 {

--- a/test/WebSites/CustomizedUi/Properties/launchSettings.json
+++ b/test/WebSites/CustomizedUi/Properties/launchSettings.json
@@ -1,4 +1,12 @@
 {
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:19183/",
+      "sslPort": 0
+    }
+  },
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
@@ -11,7 +19,7 @@
     "web": {
       "commandName": "web",
       "environmentVariables": {
-        "ASPNET_ENV": "Development"
+        "Hosting:Environment": "Development"
       }
     }
   }

--- a/test/WebSites/CustomizedUi/Startup.cs
+++ b/test/WebSites/CustomizedUi/Startup.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CustomizedUi

--- a/test/WebSites/CustomizedUi/project.json
+++ b/test/WebSites/CustomizedUi/project.json
@@ -3,25 +3,26 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Diagnostics": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc1-final",
-    "Swashbuckle.SwaggerGen": "6.0.0-rc1-final",
-    "Swashbuckle.SwaggerUi": "6.0.0-rc1-final"
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc.Dnx": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-*",
+    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "Swashbuckle.SwaggerGen": "6.0.0-rc2",
+    "Swashbuckle.SwaggerUi": "6.0.0-rc2"
   },
 
   "commands": {
-    "web": "Microsoft.AspNet.Server.Kestrel"
+    "web": "Microsoft.AspNetCore.Server.Kestrel"
   },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "dnx451": { }
   },
 
   "exclude": [

--- a/test/WebSites/MultipleVersions/Controllers/VersionedActionsController.cs
+++ b/test/WebSites/MultipleVersions/Controllers/VersionedActionsController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using MultipleVersions.Versioning;
 
 namespace MultipleVersions.Controllers

--- a/test/WebSites/MultipleVersions/Startup.cs
+++ b/test/WebSites/MultipleVersions/Startup.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Hosting;
-using Microsoft.AspNet.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.SwaggerGen.Generator;
@@ -41,11 +41,11 @@ namespace MultipleVersions
         }
 
         // Configure is called after ConfigureServices is called.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app)
         {
-            loggerFactory.MinimumLevel = LogLevel.Information;
-            loggerFactory.AddConsole();
-            loggerFactory.AddDebug();
+            var factory = app.ApplicationServices.GetRequiredService<ILoggerFactory>();
+            factory.AddConsole();
+            factory.AddDebug();
 
             // Add the platform handler to the request pipeline.
             app.UseIISPlatformHandler();

--- a/test/WebSites/MultipleVersions/Swagger/SwaggerUiController.cs
+++ b/test/WebSites/MultipleVersions/Swagger/SwaggerUiController.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace MultipleVersions.Swagger
 {

--- a/test/WebSites/MultipleVersions/Versioning/VersionsAttribute.cs
+++ b/test/WebSites/MultipleVersions/Versioning/VersionsAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
 using System.Linq;
 
 namespace MultipleVersions.Versioning

--- a/test/WebSites/MultipleVersions/project.json
+++ b/test/WebSites/MultipleVersions/project.json
@@ -3,24 +3,26 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc1-final",
-    "Swashbuckle.SwaggerGen": "6.0.0-rc1-final",
-    "Swashbuckle.SwaggerUi": "6.0.0-rc1-final"
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc.Dnx": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-*",
+    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "Swashbuckle.SwaggerGen": "6.0.0-rc2",
+    "Swashbuckle.SwaggerUi": "6.0.0-rc2"
   },
 
   "commands": {
-    "web": "Microsoft.AspNet.Server.Kestrel"
+    "web": "Microsoft.AspNetCore.Server.Kestrel"
   },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "dnx451": { }
   },
 
   "exclude": [

--- a/test/WebSites/SecuritySchemes/Controllers/OAuthProtectedController.cs
+++ b/test/WebSites/SecuritySchemes/Controllers/OAuthProtectedController.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace SecuritySchemes.Controllers
 {

--- a/test/WebSites/SecuritySchemes/Startup.cs
+++ b/test/WebSites/SecuritySchemes/Startup.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.SwaggerGen.Generator;

--- a/test/WebSites/SecuritySchemes/Swagger/AssignSecurityRequirements.cs
+++ b/test/WebSites/SecuritySchemes/Swagger/AssignSecurityRequirements.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
 using System.Collections.Generic;
-using Microsoft.AspNet.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Swashbuckle.SwaggerGen.Generator;
 
 namespace SecuritySchemes.Swagger

--- a/test/WebSites/SecuritySchemes/project.json
+++ b/test/WebSites/SecuritySchemes/project.json
@@ -3,24 +3,26 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc1-final",
-    "Swashbuckle.SwaggerGen": "6.0.0-rc1-final",
-    "Swashbuckle.SwaggerUi": "6.0.0-rc1-final"
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc.Dnx": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-*",
+    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "Swashbuckle.SwaggerGen": "6.0.0-rc2",
+    "Swashbuckle.SwaggerUi": "6.0.0-rc2"
   },
 
   "commands": {
-    "web": "Microsoft.AspNet.Server.Kestrel"
+    "web": "Microsoft.AspNetCore.Server.Kestrel"
   },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "dnx451": { }
   },
 
   "exclude": [

--- a/test/WebSites/VirtualDirectory/Controllers/CrudActionsController.cs
+++ b/test/WebSites/VirtualDirectory/Controllers/CrudActionsController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace VirtualDirectory.Controllers
 {

--- a/test/WebSites/VirtualDirectory/Properties/launchSettings.json
+++ b/test/WebSites/VirtualDirectory/Properties/launchSettings.json
@@ -1,4 +1,12 @@
 {
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:19182/",
+      "sslPort": 0
+    }
+  },
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
@@ -11,7 +19,7 @@
     "web": {
       "commandName": "web",
       "environmentVariables": {
-        "ASPNET_ENV": "Development"
+        "Hosting:Environment": "Development"
       }
     }
   }

--- a/test/WebSites/VirtualDirectory/Startup.cs
+++ b/test/WebSites/VirtualDirectory/Startup.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Hosting;
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 

--- a/test/WebSites/VirtualDirectory/project.json
+++ b/test/WebSites/VirtualDirectory/project.json
@@ -3,15 +3,18 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc1-final",
-    "Swashbuckle.SwaggerGen": "6.0.0-rc1-final",
-    "Swashbuckle.SwaggerUi": "6.0.0-rc1-final"
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc.Dnx": "1.0.0-*",
+    "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-*",
+    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "Swashbuckle.SwaggerGen": "6.0.0-rc2",
+    "Swashbuckle.SwaggerUi": "6.0.0-rc2"
   },
 
   "commands": {
@@ -19,8 +22,7 @@
   },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "dnx451": { }
   },
 
   "exclude": [


### PR DESCRIPTION
Migrated to asp.net core rc2. working on Dnx.

testing framework's packages could not resolve.

Dnx will be replaced by .NetCore(CLI), not release yet(visual studio does not support too). 
This should be a temporary version. Hope the next version without too many changes   
