### PR TITLE
Fix Response Headers collection type to match Swagger spec

### DIFF
--- a/src/Swashbuckle.SwaggerGen/Generator/SwaggerDocument.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SwaggerDocument.cs
@@ -344,7 +344,7 @@ namespace Swashbuckle.SwaggerGen.Generator
 
         public Schema Schema { get; set; }
 
-        public IList<Header> Headers { get; set; }
+        public IDictionary<string, Header> Headers { get; set; }
 
         public object Examples { get; set; }
     }


### PR DESCRIPTION
Changes `Response.Headers` collection type to `IDictionary<string, Header>`. This fixes the output `SwaggerDocument` to match the Swagger schema.