### PR TITLE
AppBuilder extensions should return the builder for chaining.

### DIFF
--- a/src/Swashbuckle.SwaggerGen/Application/SwaggerGenBuilderExtensions.cs
+++ b/src/Swashbuckle.SwaggerGen/Application/SwaggerGenBuilderExtensions.cs
@@ -6,13 +6,13 @@ namespace Microsoft.AspNet.Builder
 {
     public static class SwaggerGenBuilderExtensions
     {
-        public static void UseSwaggerGen(
+        public static IApplicationBuilder UseSwaggerGen(
             this IApplicationBuilder app,
             string routeTemplate = "swagger/{apiVersion}/swagger.json")
         {
             ThrowIfServiceNotRegistered(app.ApplicationServices);
 
-            app.UseMiddleware<SwaggerGenMiddleware>(routeTemplate);
+            return app.UseMiddleware<SwaggerGenMiddleware>(routeTemplate);
         }
 
         private static void ThrowIfServiceNotRegistered(IServiceProvider applicationServices)

--- a/src/Swashbuckle.SwaggerUi/Application/SwaggerUiBuilderExtensions.cs
+++ b/src/Swashbuckle.SwaggerUi/Application/SwaggerUiBuilderExtensions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNet.Builder
 {
     public static class SwaggerUiBuilderExtensions
     {
-        public static void  UseSwaggerUi(
+        public static IApplicationBuilder  UseSwaggerUi(
             this IApplicationBuilder app,
             string baseRoute = "swagger/ui",
             string swaggerUrl = "/swagger/v1/swagger.json")
@@ -31,6 +31,7 @@ namespace Microsoft.AspNet.Builder
                 "Swashbuckle.SwaggerUi.bower_components.swagger_ui.dist");
 
             app.UseFileServer(options);
+            return app;
         }
     }
 }


### PR DESCRIPTION
By convention, extensions to `IAppBuilder` should return the builder so additional middleware can be chained in.