### PR TITLE
Fixed ref schema error message

### DIFF
--- a/src/Swashbuckle.SwaggerGen/Generator/SchemaRegistry.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SchemaRegistry.cs
@@ -121,7 +121,7 @@ namespace Swashbuckle.SwaggerGen.Generator
             if (_referencedTypeMap.ContainsKey(schemaId) && _referencedTypeMap[schemaId] != type)
                 throw new InvalidOperationException(string.Format(
                     "Conflicting schemaIds: Duplicate schemaIds detected for types {0} and {1}. " +
-                    "See the config setting - \"UseFullTypeNameInSchemaIds\" for a potential workaround",
+                    "Set the SchemaRegistryOptions.SchemaIdSelector to \"t => t.FriendlyId(true)\" for a potential workaround.",
                     type.FullName, _referencedTypeMap[schemaId].FullName));
 
             if (!_referencedTypeMap.ContainsKey(schemaId))


### PR DESCRIPTION
Updated the error message used in CreateRefSchema to indicate the fix for duplicate schema IDs given the new configuration mechanism.