### PR TITLE
.NET Core RC2 update including UnitTests

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sources": [ "src", "test" ],
   "sdk": {
-    "version": "1.0.0-rc1-final",
+    "version": "1.0.0-preview1-002702",
     "runtime": "clr",
     "architecture": "x86"
   },

--- a/src/Swashbuckle.SwaggerGen/Annotations/XmlCommentsOperationFilter.cs
+++ b/src/Swashbuckle.SwaggerGen/Annotations/XmlCommentsOperationFilter.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
 using System.Xml.XPath;
-using Microsoft.AspNet.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Swashbuckle.SwaggerGen.Generator;
 
 namespace Swashbuckle.SwaggerGen.Annotations

--- a/src/Swashbuckle.SwaggerGen/Application/SwaggerApplicationConvention.cs
+++ b/src/Swashbuckle.SwaggerGen/Application/SwaggerApplicationConvention.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Mvc.ApplicationModels;
+﻿using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
 namespace Swashbuckle.SwaggerGen.Application
 {

--- a/src/Swashbuckle.SwaggerGen/Application/SwaggerGenBuilderExtensions.cs
+++ b/src/Swashbuckle.SwaggerGen/Application/SwaggerGenBuilderExtensions.cs
@@ -2,7 +2,7 @@
 using Swashbuckle.SwaggerGen.Application;
 using Swashbuckle.SwaggerGen.Generator;
 
-namespace Microsoft.AspNet.Builder
+namespace Microsoft.AspNetCore.Builder
 {
     public static class SwaggerGenBuilderExtensions
     {

--- a/src/Swashbuckle.SwaggerGen/Application/SwaggerGenMIddleware.cs
+++ b/src/Swashbuckle.SwaggerGen/Application/SwaggerGenMIddleware.cs
@@ -1,9 +1,9 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Routing;
-using Microsoft.AspNet.Routing.Template;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Template;
 using Newtonsoft.Json;
 using Swashbuckle.SwaggerGen.Generator;
 

--- a/src/Swashbuckle.SwaggerGen/Application/SwaggerGenOptions.cs
+++ b/src/Swashbuckle.SwaggerGen/Application/SwaggerGenOptions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.XPath;
-using Microsoft.AspNet.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Swashbuckle.SwaggerGen.Generator;
 using Swashbuckle.SwaggerGen.Annotations;

--- a/src/Swashbuckle.SwaggerGen/Application/SwaggerGenServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.SwaggerGen/Application/SwaggerGenServiceCollectionExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.ApiExplorer;
-using Microsoft.Extensions.OptionsModel;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.Options;
 using Swashbuckle.SwaggerGen.Application;
 using Swashbuckle.SwaggerGen.Generator;
 

--- a/src/Swashbuckle.SwaggerGen/Generator/ApiDescriptionExtensions.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/ApiDescriptionExtensions.cs
@@ -3,8 +3,8 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
-using Microsoft.AspNet.Mvc.ApiExplorer;
-using Microsoft.AspNet.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
 
 namespace Swashbuckle.SwaggerGen.Generator
 {
@@ -31,8 +31,9 @@ namespace Swashbuckle.SwaggerGen.Generator
 
         public static IEnumerable<string> Produces(this ApiDescription apiDescription)
         {
-            return apiDescription.SupportedResponseFormats
-                .Select(format => format.MediaType.MediaType)
+            return apiDescription.SupportedResponseTypes
+                .SelectMany(responseTypes => responseTypes.ApiResponseFormats)
+                .Select(format => format.MediaType)
                 .Distinct();
         }
 

--- a/src/Swashbuckle.SwaggerGen/Generator/IDocumentFilter.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/IDocumentFilter.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Mvc.ApiExplorer;
+﻿using Microsoft.AspNetCore.Mvc.ApiExplorer;
 
 namespace Swashbuckle.SwaggerGen.Generator
 {

--- a/src/Swashbuckle.SwaggerGen/Generator/IOperationFilter.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/IOperationFilter.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Mvc.ApiExplorer;
+﻿using Microsoft.AspNetCore.Mvc.ApiExplorer;
 
 namespace Swashbuckle.SwaggerGen.Generator
 {

--- a/src/Swashbuckle.SwaggerGen/Generator/SchemaRegistry.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SchemaRegistry.cs
@@ -141,7 +141,7 @@ namespace Swashbuckle.SwaggerGen.Generator
                 {
                     Type = "object",
                     Properties = Enum.GetNames(keyType).ToDictionary(
-                        (name) => dictionaryContract.PropertyNameResolver(name),
+                        (name) => dictionaryContract.DictionaryKeyResolver(name),
                         (name) => CreateInlineSchema(valueType)
                     )
                 };

--- a/src/Swashbuckle.SwaggerGen/Generator/SwaggerProvider.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SwaggerProvider.cs
@@ -144,12 +144,6 @@ namespace Swashbuckle.SwaggerGen.Generator
                     responses.Add("200", CreateSuccessResponse(responseType, schemaRegistry));
             }
 
-            //var responseType = apiDescription.SupportedResponseTypes.FirstOrDefault(apiResponseType => apiResponseType.Type == typeof(void));
-            //if (responseType == null)
-            //    responses.Add("204", new Response { Description = "No Content" });
-            //else
-            //    responses.Add("200", CreateSuccessResponse(responseType.Type, schemaRegistry));
-
             var operation = new Operation
             {
                 Tags = (groupName != null) ? new[] { groupName } : null,

--- a/src/Swashbuckle.SwaggerGen/Generator/SwaggerProvider.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SwaggerProvider.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 
 namespace Swashbuckle.SwaggerGen.Generator
 {
@@ -79,7 +79,7 @@ namespace Swashbuckle.SwaggerGen.Generator
             // Group further by http method
             var perMethodGrouping = apiDescriptions
                 .GroupBy(apiDesc => apiDesc.HttpMethod);
-                
+
             foreach (var group in perMethodGrouping)
             {
                 var httpMethod = group.Key;
@@ -135,10 +135,20 @@ namespace Swashbuckle.SwaggerGen.Generator
                 .ToList();
 
             var responses = new Dictionary<string, Response>();
-            if (apiDescription.ResponseType == typeof(void))
-                responses.Add("204", new Response { Description = "No Content" });
-            else
-                responses.Add("200", CreateSuccessResponse(apiDescription.ResponseType, schemaRegistry));
+            var responseTypes = apiDescription.SupportedResponseTypes.Select(responseType => responseType.Type);
+            foreach (var responseType in responseTypes)
+            {
+                if (responseType == typeof(void))
+                    responses.Add("204", new Response { Description = "No Content" });
+                else
+                    responses.Add("200", CreateSuccessResponse(responseType, schemaRegistry));
+            }
+
+            //var responseType = apiDescription.SupportedResponseTypes.FirstOrDefault(apiResponseType => apiResponseType.Type == typeof(void));
+            //if (responseType == null)
+            //    responses.Add("204", new Response { Description = "No Content" });
+            //else
+            //    responses.Add("200", CreateSuccessResponse(responseType.Type, schemaRegistry));
 
             var operation = new Operation
             {

--- a/src/Swashbuckle.SwaggerGen/Generator/SwaggerProvider.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SwaggerProvider.cs
@@ -135,13 +135,18 @@ namespace Swashbuckle.SwaggerGen.Generator
                 .ToList();
 
             var responses = new Dictionary<string, Response>();
-            var responseTypes = apiDescription.SupportedResponseTypes.Select(responseType => responseType.Type);
-            foreach (var responseType in responseTypes)
+            var descriptions = apiDescription.SupportedResponseTypes;
+
+            if (!descriptions.Any())
             {
-                if (responseType == typeof(void))
-                    responses.Add("204", new Response { Description = "No Content" });
-                else
-                    responses.Add("200", CreateSuccessResponse(responseType, schemaRegistry));
+                responses.Add("204", new Response { Description = "No Content" });
+            }
+            else
+            {
+                foreach (var description in descriptions.OrderBy(responseType => responseType.StatusCode))
+                {
+                    responses.Add("200", CreateSuccessResponse(description.Type, schemaRegistry));
+                }
             }
 
             var operation = new Operation

--- a/src/Swashbuckle.SwaggerGen/Generator/SwaggerProviderOptions.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SwaggerProviderOptions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.AspNet.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 
 namespace Swashbuckle.SwaggerGen.Generator
 {

--- a/src/Swashbuckle.SwaggerGen/Swashbuckle.SwaggerGen.xproj
+++ b/src/Swashbuckle.SwaggerGen/Swashbuckle.SwaggerGen.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>4ac6db4a-cba2-493d-88f8-82d631b9da7b</ProjectGuid>
     <RootNamespace>Swashbuckle.SwaggerGen</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Swashbuckle.SwaggerGen/project.json
+++ b/src/Swashbuckle.SwaggerGen/project.json
@@ -1,21 +1,24 @@
 ﻿{
-  "version": "6.0.0-rc1-final",
-  "description": "Swashbuckle - Swagger Generator for WebApi (AspNet 5.0)",
-  "summary": "Swagger Generator component for next generation of Swashbuckle, targeting AspNet 5.0 (vNext)",
-  "authors": [ "Richard Morris" ],
-  "tags": [ "Swagger Documentation Discovery Help WebApi AspNet vNext" ],
-  "projectUrl": "https://github.com/domaindrivendev/Swashbuckle",
-  "licenseUrl": "https://github.com/domaindrivendev/Swashbuckle/LICENSE",
+  "version": "6.0.0-rc2-final",
+  "description": "Swashbuckle - Swagger Generator for WebApi (AspNet Core)",
+  "packOptions": {
+    "summary": "Swagger Generator component for next generation of Swashbuckle, targeting AspNet Core",
+    "authors": [ "Richard Morris" ],
+    "tags": [ "Swagger Documentation Discovery Help WebApi AspNet vNext" ],
+    "projectUrl": "https://github.com/domaindrivendev/Swashbuckle",
+    "licenseUrl": "https://github.com/domaindrivendev/Swashbuckle/LICENSE"
+  },
 
   "dependencies": {
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final"
+    "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final"
   },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": {
+    "net451": { },
+    "netstandard1.5": {
+      "imports": "dnxcore50",
       "dependencies": {
-        "System.Xml.XPath": "4.0.0"
+        "System.Xml.XPath": "4.0.1-rc2-24027"
       }
     }
   }

--- a/src/Swashbuckle.SwaggerUi/Application/RedirectMiddleware.cs
+++ b/src/Swashbuckle.SwaggerUi/Application/RedirectMiddleware.cs
@@ -1,8 +1,7 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Routing;
-using Microsoft.AspNet.Routing.Template;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Template;
 
 namespace Swashbuckle.Application
 {

--- a/src/Swashbuckle.SwaggerUi/Application/SwaggerUiBuilderExtensions.cs
+++ b/src/Swashbuckle.SwaggerUi/Application/SwaggerUiBuilderExtensions.cs
@@ -1,9 +1,9 @@
 ﻿using System.Reflection;
-using Microsoft.AspNet.FileProviders;
-using Microsoft.AspNet.StaticFiles;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.AspNetCore.StaticFiles;
 using Swashbuckle.Application;
 
-namespace Microsoft.AspNet.Builder
+namespace Microsoft.AspNetCore.Builder
 {
     public static class SwaggerUiBuilderExtensions
     {

--- a/src/Swashbuckle.SwaggerUi/Application/SwaggerUiMIddleware.cs
+++ b/src/Swashbuckle.SwaggerUi/Application/SwaggerUiMIddleware.cs
@@ -4,10 +4,9 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Text;
 using System.Linq;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Routing;
-using Microsoft.AspNet.Routing.Template;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Template;
 
 namespace Swashbuckle.Application
 {

--- a/src/Swashbuckle.SwaggerUi/Swashbuckle.SwaggerUi.xproj
+++ b/src/Swashbuckle.SwaggerUi/Swashbuckle.SwaggerUi.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>1c14cc40-1d89-4da9-a1d8-237fd8922371</ProjectGuid>
     <RootNamespace>Swashbuckle</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Swashbuckle.SwaggerUi/project.json
+++ b/src/Swashbuckle.SwaggerUi/project.json
@@ -16,7 +16,9 @@
   },
 
   "buildOptions": {
-    "embed": [ "SwaggerUi", "bower_components/swagger-ui/dist" ]
+    "embed": {
+      "include": [ "SwaggerUi/**", "bower_components/swagger-ui/dist/**" ]
+    }
   },
 
   "frameworks": {

--- a/src/Swashbuckle.SwaggerUi/project.json
+++ b/src/Swashbuckle.SwaggerUi/project.json
@@ -1,22 +1,28 @@
 ﻿{
-  "version": "6.0.0-rc1-final",
-  "description": "Swashbuckle - Swagger UI for WebApi (AspNet 5.0)",
-  "summary": "Swagger UI component for next generation of Swashbuckle, targeting AspNet 5.0 (vNext)",
-  "authors": [ "Richard Morris" ],
-  "tags": [ "Swagger SwaggerUi Documentation Discovery Help WebApi AspNet vNext" ],
-  "projectUrl": "https://github.com/domaindrivendev/Swashbuckle",
-  "licenseUrl": "https://github.com/domaindrivendev/Swashbuckle/LICENSE",
-
-  "dependencies": {
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.AspNet.FileProviders.Embedded": "1.0.0-rc1-final"
+  "version": "6.0.0-rc2-final",
+  "description": "Swashbuckle - Swagger UI for WebApi (AspNet Core)",
+  "packOptions": {
+    "summary": "Swagger UI component for next generation of Swashbuckle, targeting AspNet Core",
+    "authors": [ "Richard Morris" ],
+    "tags": [ "Swagger SwaggerUi Documentation Discovery Help WebApi AspNet vNext" ],
+    "projectUrl": "https://github.com/domaindrivendev/Swashbuckle",
+    "licenseUrl": "https://github.com/domaindrivendev/Swashbuckle/LICENSE"
   },
 
-  "resource": [ "SwaggerUi", "bower_components/swagger-ui/dist" ],
+  "dependencies": {
+    "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
+    "Microsoft.Extensions.FileProviders.Embedded": "1.0.0-rc2-final"
+  },
+
+  "buildOptions": {
+    "embed": [ "SwaggerUi", "bower_components/swagger-ui/dist" ]
+  },
 
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "net451": { },
+    "netstandard1.5": {
+      "imports": "dnxcore50"
+    }
   }
 }

--- a/test/Swashbuckle.IntegrationTests/NuGet.Config
+++ b/test/Swashbuckle.IntegrationTests/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="XUnit (MyGet)" value="https://www.myget.org/F/xunit/api/v3/index.json" />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/test/Swashbuckle.IntegrationTests/SwaggerGenIntegrationTests.cs
+++ b/test/Swashbuckle.IntegrationTests/SwaggerGenIntegrationTests.cs
@@ -35,13 +35,6 @@ namespace Swashbuckle.IntegrationTests
             Type startupType,
             string swaggerRequestUri)
         {
-            //var client = new TestServer(TestServer.CreateBuilder()
-            //    .UseStartup(startupType)
-            //    // Use a Convention to only surface ApiDescriptions if action belongs to test app assembly
-            //    .UseServices(services =>
-            //        services.Configure<MvcOptions>(c => c.Conventions.Add(new TestAppActionModel(startupType.Assembly)))
-            //    ))
-            //    .CreateClient();
             using (var testServer = new TestServer(new WebHostBuilder().UseStartup(startupType)))
             {
                 using (var client = testServer.CreateClient())

--- a/test/Swashbuckle.IntegrationTests/SwaggerGenIntegrationTests.cs
+++ b/test/Swashbuckle.IntegrationTests/SwaggerGenIntegrationTests.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.TestHost;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
+using Microsoft.AspNetCore.Hosting;
 
 namespace Swashbuckle.IntegrationTests
 {
@@ -34,18 +35,23 @@ namespace Swashbuckle.IntegrationTests
             Type startupType,
             string swaggerRequestUri)
         {
-            var client = new TestServer(TestServer.CreateBuilder()
-                .UseStartup(startupType)
-                // Use a Convention to only surface ApiDescriptions if action belongs to test app assembly
-                .UseServices(services =>
-                    services.Configure<MvcOptions>(c => c.Conventions.Add(new TestAppActionModel(startupType.Assembly)))
-                ))
-                .CreateClient();
+            //var client = new TestServer(TestServer.CreateBuilder()
+            //    .UseStartup(startupType)
+            //    // Use a Convention to only surface ApiDescriptions if action belongs to test app assembly
+            //    .UseServices(services =>
+            //        services.Configure<MvcOptions>(c => c.Conventions.Add(new TestAppActionModel(startupType.Assembly)))
+            //    ))
+            //    .CreateClient();
+            using (var testServer = new TestServer(new WebHostBuilder().UseStartup(startupType)))
+            {
+                using (var client = testServer.CreateClient())
+                {
+                    var swaggerResponse = await client.GetAsync(swaggerRequestUri);
 
-            var swaggerResponse = await client.GetAsync(swaggerRequestUri);
-
-            swaggerResponse.EnsureSuccessStatusCode();
-            await AssertValidSwaggerAsync(swaggerResponse);
+                    swaggerResponse.EnsureSuccessStatusCode();
+                    await AssertValidSwaggerAsync(swaggerResponse);
+                }
+            }
         }
 
         private async Task AssertValidSwaggerAsync(HttpResponseMessage swaggerResponse)

--- a/test/Swashbuckle.IntegrationTests/SwaggerUiIntegrationTests.cs
+++ b/test/Swashbuckle.IntegrationTests/SwaggerUiIntegrationTests.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.FileProviders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Swashbuckle.IntegrationTests
+{
+    public class SwaggerUiIntegrationTests
+    {
+        [Theory]
+        [InlineData("index.html")]
+        [InlineData("css/style.css")]
+        [InlineData("swagger-ui.js")]
+        public void SwaggerUiAssembly_ContainsEmbeddedFiles(string filePath)
+        {
+            var fileProvider = new EmbeddedFileProvider(
+                typeof(SwaggerUiBuilderExtensions).GetTypeInfo().Assembly,
+                "Swashbuckle.SwaggerUi.bower_components.swagger_ui.dist"
+            );
+
+            var fileInfo = fileProvider.GetFileInfo(filePath);
+            var directoryInfo = fileProvider.GetDirectoryContents("/");
+
+            Assert.True(fileInfo.Exists, $"File '{filePath}' doesn't exist.");
+        }
+    }
+}

--- a/test/Swashbuckle.IntegrationTests/Swashbuckle.IntegrationTests.xproj
+++ b/test/Swashbuckle.IntegrationTests/Swashbuckle.IntegrationTests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>fae3ae3a-e5b2-44b1-b402-fd96899c444b</ProjectGuid>
     <RootNamespace>Swashbuckle.IntegrationTests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/Swashbuckle.IntegrationTests/Swashbuckle.IntegrationTests.xproj.user
+++ b/test/Swashbuckle.IntegrationTests/Swashbuckle.IntegrationTests.xproj.user
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ActiveDebugProfile>test</ActiveDebugProfile>
+    <ActiveDebugProfile>Start</ActiveDebugProfile>
   </PropertyGroup>
 </Project>

--- a/test/Swashbuckle.IntegrationTests/TestAppActionModel.cs
+++ b/test/Swashbuckle.IntegrationTests/TestAppActionModel.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using Microsoft.AspNet.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
 namespace Swashbuckle.IntegrationTests
 {

--- a/test/Swashbuckle.IntegrationTests/project.json
+++ b/test/Swashbuckle.IntegrationTests/project.json
@@ -1,20 +1,28 @@
 ﻿{
   "version": "1.0.0-*",
+  "testRunner": "xunit",
+  "buildOptions": {
+    "preserveCompilationContext": true,
+    "copyToOutput": {
+      "include": [ "config.json" ]
+    }
+  },
   "dependencies": {
-    "Microsoft.AspNet.Mvc.Core": "6.0.0-rc1-final",
-    "Microsoft.AspNet.TestHost": "1.0.0-rc1-final",
-    "xunit": "2.1.0-*",
-    "xunit.runner.dnx": "2.1.0-rc1*",
+    "Microsoft.AspNetCore.Mvc.Core": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.TestHost": "1.0.0-rc2-final",
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-rc3-build10019",
+    "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",
     "Basic": "1.0.0-*",
     "CustomizedUi": "1.0.0-*",
     "MultipleVersions": "1.0.0-*",
     "SecuritySchemes": "1.0.0-*",
     "VirtualDirectory": "1.0.0-*"
   },
-  "commands": {
-    "test": "xunit.runner.dnx"
-  },
   "frameworks": {
-    "dnx451": { }
+    "net451": {
+      "dependencies": {
+      }
+    }
   }
 }

--- a/test/Swashbuckle.SwaggerGen.Test/NuGet.Config
+++ b/test/Swashbuckle.SwaggerGen.Test/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="XUnit (MyGet)" value="https://www.myget.org/F/xunit/api/v3/index.json" />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/test/Swashbuckle.SwaggerGen.Test/Swashbuckle.SwaggerGen.Test.xproj
+++ b/test/Swashbuckle.SwaggerGen.Test/Swashbuckle.SwaggerGen.Test.xproj
@@ -8,7 +8,7 @@
     <ProjectGuid>6e1df729-097e-4baa-86e4-61bd8a6c5209</ProjectGuid>
     <RootNamespace>Swashbuckle.SwaggerGen</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AssemblyName>Swashbuckle.Swagger.Test</AssemblyName>

--- a/test/Swashbuckle.SwaggerGen.Test/Swashbuckle.SwaggerGen.Test.xproj.user
+++ b/test/Swashbuckle.SwaggerGen.Test/Swashbuckle.SwaggerGen.Test.xproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ActiveDebugProfile>test</ActiveDebugProfile>
+    <ActiveDebugProfile>Start</ActiveDebugProfile>
     <ShowAllFiles>false</ShowAllFiles>
   </PropertyGroup>
 </Project>

--- a/test/Swashbuckle.SwaggerGen.Test/TestFixtures/FakeActions.cs
+++ b/test/Swashbuckle.SwaggerGen.Test/TestFixtures/FakeActions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
 using Swashbuckle.SwaggerGen.Annotations;
 using Swashbuckle.SwaggerGen.TestFixtures.Extensions;

--- a/test/Swashbuckle.SwaggerGen.Test/TestFixtures/FakeApiDescriptionGroupCollectionProvider.cs
+++ b/test/Swashbuckle.SwaggerGen.Test/TestFixtures/FakeApiDescriptionGroupCollectionProvider.cs
@@ -3,19 +3,21 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Collections.ObjectModel;
 using System.Reflection;
-using Microsoft.Extensions.OptionsModel;
-using Microsoft.AspNet.Routing;
-using Microsoft.AspNet.Routing.Constraints;
-using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.Abstractions;
-using Microsoft.AspNet.Mvc.ActionConstraints;
-using Microsoft.AspNet.Mvc.ApiExplorer;
-using Microsoft.AspNet.Mvc.Controllers;
-using Microsoft.AspNet.Mvc.Formatters;
-using Microsoft.AspNet.Mvc.Routing;
-using Microsoft.AspNet.Mvc.ModelBinding;
-using Microsoft.AspNet.Mvc.ModelBinding.Metadata;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Constraints;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Moq;
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
 
 namespace Swashbuckle.SwaggerGen.TestFixtures
 {
@@ -62,7 +64,7 @@ namespace Swashbuckle.SwaggerGen.TestFixtures
 
             descriptor.ActionConstraints = new List<IActionConstraintMetadata>();
             if (httpMethod != null)
-                descriptor.ActionConstraints.Add(new HttpMethodConstraint(new[] { httpMethod }));
+                descriptor.ActionConstraints.Add(new HttpMethodActionConstraint(new[] { httpMethod }));
 
             descriptor.AttributeRouteInfo = new AttributeRouteInfo { Template = routeTemplate };
 
@@ -123,6 +125,10 @@ namespace Swashbuckle.SwaggerGen.TestFixtures
                         MissingBindRequiredValueAccessor = name => $"A value for the '{ name }' property was not provided.",
                         MissingKeyOrValueAccessor = () => $"A value is required.",
                         ValueMustNotBeNullAccessor = value => $"The value '{ value }' is invalid.",
+                        AttemptedValueIsInvalidAccessor = (value1, value2) => $"The value '{value1}' is invalid.",
+                        UnknownValueIsInvalidAccessor = (value) => $"The value '{value}' is unknown.",
+                        ValueIsInvalidAccessor = (value) => $"The value '{value}' is invalid",
+                        ValueMustBeANumberAccessor = (value) => $"The value '{value}' must be a number"
                     }),
                     new DataAnnotationsMetadataProvider()
                 }

--- a/test/Swashbuckle.SwaggerGen.Test/project.json
+++ b/test/Swashbuckle.SwaggerGen.Test/project.json
@@ -1,15 +1,23 @@
 {
   "version": "1.0.0-*",
-  "dependencies": {
-    "xunit": "2.1.0-*",
-    "xunit.runner.dnx": "2.1.0-rc1*",
-    "Moq": "4.2-*",
-    "Swashbuckle.SwaggerGen": "6.0.0-*"
+  "testRunner": "xunit",
+  "buildOptions": {
+    "preserveCompilationContext": true,
+    "copyToOutput": {
+      "include": [ "config.json", "TestFixtures/XmlComments.xml" ]
+    }
   },
-  "commands": {
-    "test": "xunit.runner.dnx"
+  "dependencies": {
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-rc3-build10019",
+    "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",
+    "Moq": "4.2.1510.2205",
+    "Swashbuckle.SwaggerGen": "6.0.0-rc2-final"
   },
   "frameworks": {
-    "dnx451": { }
+    "net451": {
+      "dependencies": {
+      }
+    }
   }
 }

--- a/test/WebSites/Basic/Basic.xproj
+++ b/test/WebSites/Basic/Basic.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>b4c24875-7238-4408-aabf-1bb18e001312</ProjectGuid>
     <RootNamespace>Basic</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/WebSites/Basic/Controllers/CrudActionsController.cs
+++ b/test/WebSites/Basic/Controllers/CrudActionsController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Basic.Controllers
 {

--- a/test/WebSites/Basic/Controllers/DataAnnotationsController.cs
+++ b/test/WebSites/Basic/Controllers/DataAnnotationsController.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Basic.Controllers
 {

--- a/test/WebSites/Basic/Controllers/DynamicTypesController.cs
+++ b/test/WebSites/Basic/Controllers/DynamicTypesController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Dynamic;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json.Linq;
 
 namespace Basic.Controllers

--- a/test/WebSites/Basic/Controllers/FromQueryParamsController.cs
+++ b/test/WebSites/Basic/Controllers/FromQueryParamsController.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Basic.Controllers
 {

--- a/test/WebSites/Basic/Controllers/JsonAnnotationsController.cs
+++ b/test/WebSites/Basic/Controllers/JsonAnnotationsController.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/test/WebSites/Basic/Controllers/SwaggerAnnotatedController.cs
+++ b/test/WebSites/Basic/Controllers/SwaggerAnnotatedController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.SwaggerGen.Annotations;
 using Basic.Swagger;
 

--- a/test/WebSites/Basic/Program.cs
+++ b/test/WebSites/Basic/Program.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Basic
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/test/WebSites/Basic/Properties/launchSettings.json
+++ b/test/WebSites/Basic/Properties/launchSettings.json
@@ -1,4 +1,12 @@
 {
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:60537/",
+      "sslPort": 0
+    }
+  },
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",

--- a/test/WebSites/Basic/Startup.cs
+++ b/test/WebSites/Basic/Startup.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.PlatformAbstractions;
@@ -14,13 +14,13 @@ namespace Basic
 {
     public class Startup
     {
-        private readonly IApplicationEnvironment _appEnv;
+        private readonly ApplicationEnvironment _appEnv;
         private readonly IHostingEnvironment _hostingEnv;
 
-        public Startup(IHostingEnvironment hostingEnv, IApplicationEnvironment appEnv)
+        public Startup(IHostingEnvironment hostingEnv)
         {
             _hostingEnv = hostingEnv;
-            _appEnv = appEnv;
+            _appEnv = PlatformServices.Default.Application;
         }
 
         // This method gets called by a runtime.
@@ -59,7 +59,12 @@ namespace Basic
                 {
                     c.IncludeXmlComments(string.Format(@"{0}\artifacts\bin\Basic\{1}\{2}{3}\Basic.xml",
                         GetSolutionBasePath(),
-                        _appEnv.Configuration,
+                        // TODO: Find a better way to replace _appEnv.Configuration,
+#if DEBUG
+                        "Debug",
+#else
+                        "Release"
+#endif
                         _appEnv.RuntimeFramework.Identifier,
                         _appEnv.RuntimeFramework.Version.ToString().Replace(".", string.Empty)));
                 });
@@ -69,12 +74,8 @@ namespace Basic
         // Configure is called after ConfigureServices is called.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            loggerFactory.MinimumLevel = LogLevel.Information;
-            loggerFactory.AddConsole();
-            loggerFactory.AddDebug();
-
-            // Add the platform handler to the request pipeline.
-            app.UseIISPlatformHandler();
+            loggerFactory.AddConsole(LogLevel.Information);
+            loggerFactory.AddDebug(LogLevel.Information);
 
             // Configure the HTTP request pipeline.
             app.UseStaticFiles();

--- a/test/WebSites/Basic/project.json
+++ b/test/WebSites/Basic/project.json
@@ -2,34 +2,52 @@
   "webroot": "wwwroot",
   "version": "1.0.0-*",
 
+  "buildOptions": {
+
+    "compile": {
+      "exclude": [
+        "wwwroot",
+        "node_modules"
+      ]
+    }
+  },
+
+  "publishOptions": {
+    "exclude": [
+      "**.user",
+      "**.vspscc"
+    ]
+  },
+
   "dependencies": {
-    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Diagnostics": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc1-final",
-    "Swashbuckle.SwaggerGen": "6.0.0-rc1-final",
-    "Swashbuckle.SwaggerUi": "6.0.0-rc1-final"
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final",
+    "Swashbuckle.SwaggerGen": "6.0.0-rc2-final",
+    "Swashbuckle.SwaggerUi": "6.0.0-rc2-final"
   },
 
   "commands": {
     "web": "Microsoft.AspNet.Server.Kestrel"
   },
-
-  "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+  "runtimes": {
+    "win7-x64": { }
   },
-
-  "exclude": [
-    "wwwroot",
-    "node_modules"
-  ],
-  "publishExclude": [
-    "**.user",
-    "**.vspscc"
-  ]
+  "frameworks": {
+    "net451": { },
+    "netcoreapp1.0": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-rc2-3002702",
+          "type": "platform"
+        }
+      }
+    }
+  }
 }

--- a/test/WebSites/CustomizedUi/Controllers/CrudActionsController.cs
+++ b/test/WebSites/CustomizedUi/Controllers/CrudActionsController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace CustomizedUi.Controllers
 {

--- a/test/WebSites/CustomizedUi/CustomizedUi.xproj
+++ b/test/WebSites/CustomizedUi/CustomizedUi.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>55dce4fa-9d46-43cd-b19c-17215eee68e4</ProjectGuid>
     <RootNamespace>CustomizedUi</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/WebSites/CustomizedUi/Program.cs
+++ b/test/WebSites/CustomizedUi/Program.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CustomizedUi
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/test/WebSites/CustomizedUi/Properties/launchSettings.json
+++ b/test/WebSites/CustomizedUi/Properties/launchSettings.json
@@ -1,4 +1,12 @@
 {
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:60536/",
+      "sslPort": 0
+    }
+  },
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",

--- a/test/WebSites/CustomizedUi/Startup.cs
+++ b/test/WebSites/CustomizedUi/Startup.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CustomizedUi
@@ -15,9 +15,6 @@ namespace CustomizedUi
 
         public void Configure(IApplicationBuilder app)
         {
-            // Add the platform handler to the request pipeline.
-            app.UseIISPlatformHandler();
-
             app.UseStaticFiles();
 
             app.UseMvc();

--- a/test/WebSites/CustomizedUi/project.json
+++ b/test/WebSites/CustomizedUi/project.json
@@ -3,33 +3,51 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Diagnostics": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc1-final",
-    "Swashbuckle.SwaggerGen": "6.0.0-rc1-final",
-    "Swashbuckle.SwaggerUi": "6.0.0-rc1-final"
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final",
+    "Swashbuckle.SwaggerGen": "6.0.0-rc2-final",
+    "Swashbuckle.SwaggerUi": "6.0.0-rc2-final"
+  },
+
+  "buildOptions": {
+    "emitEntryPoint": true,
+    "compile": {
+      "exclude": [
+        "wwwroot",
+        "node_modules"
+      ]
+    }
+  },
+
+  "publishOptions": {
+    "exclude": [
+      "**.user",
+      "**.vspscc"
+    ]
   },
 
   "commands": {
     "web": "Microsoft.AspNet.Server.Kestrel"
   },
-
-  "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+  "runtimes": {
+    "win7-x64": { }
   },
-
-  "exclude": [
-    "wwwroot",
-    "node_modules"
-  ],
-  "publishExclude": [
-    "**.user",
-    "**.vspscc"
-  ]
+  "frameworks": {
+    "net451": { },
+    "netcoreapp1.0": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-rc2-3002702",
+          "type": "platform"
+        }
+      }
+    }
+  }
 }

--- a/test/WebSites/MultipleVersions/Controllers/VersionedActionsController.cs
+++ b/test/WebSites/MultipleVersions/Controllers/VersionedActionsController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using MultipleVersions.Versioning;
 
 namespace MultipleVersions.Controllers

--- a/test/WebSites/MultipleVersions/MultipleVersions.xproj
+++ b/test/WebSites/MultipleVersions/MultipleVersions.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>b23c0c45-5b6f-4428-851b-766408517b13</ProjectGuid>
     <RootNamespace>MultipleVersions</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/WebSites/MultipleVersions/Program.cs
+++ b/test/WebSites/MultipleVersions/Program.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MultipleVersions
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/test/WebSites/MultipleVersions/Startup.cs
+++ b/test/WebSites/MultipleVersions/Startup.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Hosting;
-using Microsoft.AspNet.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.SwaggerGen.Generator;
@@ -43,12 +43,8 @@ namespace MultipleVersions
         // Configure is called after ConfigureServices is called.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            loggerFactory.MinimumLevel = LogLevel.Information;
-            loggerFactory.AddConsole();
-            loggerFactory.AddDebug();
-
-            // Add the platform handler to the request pipeline.
-            app.UseIISPlatformHandler();
+            loggerFactory.AddConsole(LogLevel.Information);
+            loggerFactory.AddDebug(LogLevel.Information);
 
             // Configure the HTTP request pipeline.
             app.UseStaticFiles();

--- a/test/WebSites/MultipleVersions/Swagger/SwaggerUiController.cs
+++ b/test/WebSites/MultipleVersions/Swagger/SwaggerUiController.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace MultipleVersions.Swagger
 {

--- a/test/WebSites/MultipleVersions/Versioning/VersionsAttribute.cs
+++ b/test/WebSites/MultipleVersions/Versioning/VersionsAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
 using System.Linq;
 
 namespace MultipleVersions.Versioning
@@ -10,9 +10,12 @@ namespace MultipleVersions.Versioning
         public VersionsAttribute(params string[] acceptedVersions)
         {
             AcceptedVersions = acceptedVersions;
+            IsReusable = true;
         }
 
         public string[] AcceptedVersions { get; private set; }
+
+        public bool IsReusable { get; }
 
         public IActionConstraint CreateInstance(IServiceProvider services)
         {

--- a/test/WebSites/MultipleVersions/project.json
+++ b/test/WebSites/MultipleVersions/project.json
@@ -2,33 +2,49 @@
   "webroot": "wwwroot",
   "version": "1.0.0-*",
 
+  "buildOptions": {
+    "compile": {
+      "exclude": [
+        "wwwroot",
+        "node_modules"
+      ]
+    }
+  },
+
+  "publishOptions": {
+    "exclude": [
+      "**.user",
+      "**.vspscc"
+    ]
+  },
   "dependencies": {
-    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc1-final",
-    "Swashbuckle.SwaggerGen": "6.0.0-rc1-final",
-    "Swashbuckle.SwaggerUi": "6.0.0-rc1-final"
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final",
+    "Swashbuckle.SwaggerGen": "6.0.0-rc2-final",
+    "Swashbuckle.SwaggerUi": "6.0.0-rc2-final"
   },
 
   "commands": {
     "web": "Microsoft.AspNet.Server.Kestrel"
   },
-
-  "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+  "runtimes": {
+    "win7-x64": { }
   },
-
-  "exclude": [
-    "wwwroot",
-    "node_modules"
-  ],
-  "publishExclude": [
-    "**.user",
-    "**.vspscc"
-  ]
+  "frameworks": {
+    "net451": { },
+    "netcoreapp1.0": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-rc2-3002702",
+          "type": "platform"
+        }
+      }
+    }
+  }
 }

--- a/test/WebSites/SecuritySchemes/Controllers/OAuthProtectedController.cs
+++ b/test/WebSites/SecuritySchemes/Controllers/OAuthProtectedController.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace SecuritySchemes.Controllers
 {

--- a/test/WebSites/SecuritySchemes/Program.cs
+++ b/test/WebSites/SecuritySchemes/Program.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SecuritySchemes
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/test/WebSites/SecuritySchemes/SecuritySchemes.xproj
+++ b/test/WebSites/SecuritySchemes/SecuritySchemes.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>44cd874e-a25e-466a-99ab-544bb900a33c</ProjectGuid>
     <RootNamespace>SecuritySchemes</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/WebSites/SecuritySchemes/Startup.cs
+++ b/test/WebSites/SecuritySchemes/Startup.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.SwaggerGen.Generator;
@@ -44,12 +44,8 @@ namespace SecuritySchemes
         // Configure is called after ConfigureServices is called.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            loggerFactory.MinimumLevel = LogLevel.Information;
-            loggerFactory.AddConsole();
-            loggerFactory.AddDebug();
-
-            // Add the platform handler to the request pipeline.
-            app.UseIISPlatformHandler();
+            loggerFactory.AddConsole(LogLevel.Information);
+            loggerFactory.AddDebug(LogLevel.Information);
 
             // Configure the HTTP request pipeline.
             app.UseStaticFiles();

--- a/test/WebSites/SecuritySchemes/Swagger/AssignSecurityRequirements.cs
+++ b/test/WebSites/SecuritySchemes/Swagger/AssignSecurityRequirements.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
 using System.Collections.Generic;
-using Microsoft.AspNet.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Swashbuckle.SwaggerGen.Generator;
 
 namespace SecuritySchemes.Swagger

--- a/test/WebSites/SecuritySchemes/project.json
+++ b/test/WebSites/SecuritySchemes/project.json
@@ -2,33 +2,50 @@
   "webroot": "wwwroot",
   "version": "1.0.0-*",
 
+  "buildOptions": {
+    "emitEntryPoint": true,
+    "compile": {
+      "exclude": [
+        "wwwroot",
+        "node_modules"
+      ]
+    }
+  },
+  "publishOptions": {
+    "exclude": [
+      "**.user",
+      "**.vspscc"
+    ]
+  },
+
   "dependencies": {
-    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc1-final",
-    "Swashbuckle.SwaggerGen": "6.0.0-rc1-final",
-    "Swashbuckle.SwaggerUi": "6.0.0-rc1-final"
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final",
+    "Swashbuckle.SwaggerGen": "6.0.0-rc2-final",
+    "Swashbuckle.SwaggerUi": "6.0.0-rc2-final"
   },
 
   "commands": {
     "web": "Microsoft.AspNet.Server.Kestrel"
   },
-
-  "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+  "runtimes": {
+    "win7-x64": { }
   },
-
-  "exclude": [
-    "wwwroot",
-    "node_modules"
-  ],
-  "publishExclude": [
-    "**.user",
-    "**.vspscc"
-  ]
+  "frameworks": {
+    "net451": { },
+    "netcoreapp1.0": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-rc2-3002702",
+          "type": "platform"
+        }
+      }
+    }
+  }
 }

--- a/test/WebSites/VirtualDirectory/Controllers/CrudActionsController.cs
+++ b/test/WebSites/VirtualDirectory/Controllers/CrudActionsController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace VirtualDirectory.Controllers
 {

--- a/test/WebSites/VirtualDirectory/Program.cs
+++ b/test/WebSites/VirtualDirectory/Program.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace VirtualDirectory
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/test/WebSites/VirtualDirectory/Properties/launchSettings.json
+++ b/test/WebSites/VirtualDirectory/Properties/launchSettings.json
@@ -1,4 +1,12 @@
 {
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:60538/",
+      "sslPort": 0
+    }
+  },
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",

--- a/test/WebSites/VirtualDirectory/Startup.cs
+++ b/test/WebSites/VirtualDirectory/Startup.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Hosting;
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -26,15 +26,11 @@ namespace VirtualDirectory
         // Configure is called after ConfigureServices is called.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            loggerFactory.MinimumLevel = LogLevel.Information;
-            loggerFactory.AddConsole();
-            loggerFactory.AddDebug();
+            loggerFactory.AddConsole(LogLevel.Information);
+            loggerFactory.AddDebug(LogLevel.Information);
 
             app.Map("/vdir", subApp =>
             {
-                // Add the platform handler to the request pipeline.
-                subApp.UseIISPlatformHandler();
-
                 // Configure the HTTP request pipeline.
                 subApp.UseStaticFiles();
 

--- a/test/WebSites/VirtualDirectory/VirtualDirectory.xproj
+++ b/test/WebSites/VirtualDirectory/VirtualDirectory.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>28b55065-bfe6-4c82-afd3-6157408bbc37</ProjectGuid>
     <RootNamespace>VirtualDirectory</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/WebSites/VirtualDirectory/project.json
+++ b/test/WebSites/VirtualDirectory/project.json
@@ -2,33 +2,47 @@
   "webroot": "wwwroot",
   "version": "1.0.0-*",
 
+  "buildOptions": {
+    "exclude": [
+      "wwwroot",
+      "node_modules"
+    ]
+  },
+  "publishOptions": {
+    "exclude": [
+      "**.user",
+      "**.vspscc"
+    ]
+  },
+
   "dependencies": {
-    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc1-final",
-    "Swashbuckle.SwaggerGen": "6.0.0-rc1-final",
-    "Swashbuckle.SwaggerUi": "6.0.0-rc1-final"
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final",
+    "Swashbuckle.SwaggerGen": "6.0.0-rc2-final",
+    "Swashbuckle.SwaggerUi": "6.0.0-rc2-final"
   },
 
   "commands": {
     "web": "Microsoft.AspNet.Server.Kestrel"
   },
-
-  "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+  "runtimes": {
+    "win7-x64": { }
   },
-
-  "exclude": [
-    "wwwroot",
-    "node_modules"
-  ],
-  "publishExclude": [
-    "**.user",
-    "**.vspscc"
-  ]
+  "frameworks": {
+    "net451": { },
+    "netcoreapp1.0": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-rc2-3002702",
+          "type": "platform"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Today I did a more complete port to RC2. 

The previous pull requests didn't ported the UnitTests. I have managed to get all the tests pass, except for 2.

I had to use RC3 of xunit runner, as the RC2 contains a but where tests fail on x64 as mentioned in this issues

https://github.com/xunit/xunit/issues/843
https://github.com/dotnet/cli/issues/3069#issuecomment-220332924
https://github.com/xunit/xunit/issues/850#issuecomment-220832417

Failing Test is GetSwagger_SetsResponseStatusCodeAndSchema_AccordingToActionReturnType with `[InlineData(nameof(FakeActions.ReturnsActionResult), "200", false)]` and `[InlineData(nameof(FakeActions.ReturnsVoid), "204", false)]`. I don't know exactly why they fail, but the `SupportedResponseTypes`in SwaggerProvider.cs, line 138 is empty and the loop never entered so the call to `responses.Add(...)` is never called and the array in the test is null. 

I wasn't sure what the expected behaviour would be, when there is more than one supported type or none at all, so I left it out as is so @domaindrivendev can have a look at it.

Hope you'll be able to get it compile on your machine (I got VS 2015 Update 2 with .NET Core Preview Tooling - took me a while to get the old tools uninstalled and get rid of dnx remain). 

I was unable to find a way to replace the `_appEnv.Configuration,`, so for now I used preprocessor directives. It's not very clean way to solve it, but `IApplicationEnvironment` was removed/placed into the static  `PlatformServices` class, but there is no `Configuration` property anymore. 