### PR TITLE
Fix SwaggerProvider to use "formData"

### DIFF
--- a/src/Swashbuckle.SwaggerGen/Generator/SwaggerProvider.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SwaggerProvider.cs
@@ -183,7 +183,7 @@ namespace Swashbuckle.SwaggerGen.Generator
                 var nonBodyParam = new NonBodyParameter
                 {
                     Name = paramDesc.Name,
-                    In = source,
+                    In = (source == "form") ? "formData" : source,
                     Required = (source == "path")
                 };
 


### PR DESCRIPTION
Swagger provider was output "form" when using [FromForm] annotation.  This was not valid Swagger spec.  Updated code to use "formData" instead.
