### PR TITLE
Updates to project-files for RC2

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="AspNetCiRelease" value="https://www.myget.org/F/aspnetcirelease/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="xUnit" value="https://www.myget.org/F/xunit/" />
   </packageSources>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Swashbuckle
 =========
 
-Seamlessly adds a [Swagger](http://swagger.io/) to API's that are built with AspNet Core! It combines the built in metadata functionality ([ApiExplorer](https://github.com/aspnet/Mvc/tree/dev/src/Microsoft.AspNetCore.Mvc.ApiExplorer)) and Swagger/swagger-ui to provide a rich discovery, documentation and playground experience to your API consumers.
+Seamlessly adds a [Swagger](http://swagger.io/) to API's that are built with ASP.NET Core! It combines the built in metadata functionality ([ApiExplorer](https://github.com/aspnet/Mvc/tree/dev/src/Microsoft.AspNetCore.Mvc.ApiExplorer)) and Swagger/swagger-ui to provide a rich discovery, documentation and playground experience to your API consumers.
 
 In addition to its [Swagger](http://swagger.io/specification/) generator, Swashbuckle also contains an embedded version of the [swagger-ui](https://github.com/swagger-api/swagger-ui) which it will automatically serve up once Swashbuckle is installed. This means you can complement your API with a slick discovery UI to assist consumers with their integration efforts. Best of all, it requires minimal coding and maintenance, allowing you to focus on building an awesome API
 
@@ -21,7 +21,7 @@ Once you have a Web API that can describe itself in Swagger, you've opened the t
 
 **\*Swashbuckle 6.0.0**
 
-Because Swashbuckle 6.0.0 is built on top of the next-gen implementation of .NET and ASP.NET (AspNet Core), the source code and public interface deviate significantly from previous versions. Once a stable release of AspNet Core (RC2 at time of writing) becomes available, I'll add a transition guide for Swashbuckle. In the meantime, you'll need to figure this out yourself. Hopefully, the examples [here](https://github.com/domaindrivendev/Ahoy/tree/master/test/WebSites) and the remainder of this README will get you there!
+Because Swashbuckle 6.0.0 is built on top of the next-gen implementation of .NET and ASP.NET (ASP.NET Core), the source code and public interface deviate significantly from previous versions. Once a stable release of ASP.NET Core (RC2 at time of writing) becomes available, I'll add a transition guide for Swashbuckle. In the meantime, you'll need to figure this out yourself. Hopefully, the examples [here](https://github.com/domaindrivendev/Ahoy/tree/master/test/WebSites) and the remainder of this README will get you there!
 
 
 ## Getting Started ##

--- a/src/Swashbuckle.Swagger/project.json
+++ b/src/Swashbuckle.Swagger/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "version": "6.0.0-beta9",
-  "description": "Core components for Swashbuckle - a Swagger toolchain for AspNet Core",
+  "description": "Core components for Swashbuckle - a Swagger toolchain for ASP.NET Core",
   "authors": [ "Richard Morris" ],
 
   "packOptions": {

--- a/src/Swashbuckle.SwaggerGen/Swashbuckle.SwaggerGen.xproj
+++ b/src/Swashbuckle.SwaggerGen/Swashbuckle.SwaggerGen.xproj
@@ -4,17 +4,15 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>4ac6db4a-cba2-493d-88f8-82d631b9da7b</ProjectGuid>
     <RootNamespace>Swashbuckle.SwaggerGen</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Swashbuckle.SwaggerGen/project.json
+++ b/src/Swashbuckle.SwaggerGen/project.json
@@ -1,6 +1,6 @@
 {
   "version": "6.0.0-beta9",
-  "description": "Swagger Generator component for Swashbuckle - a Swagger toolchain for AspNet Core",
+  "description": "Swagger Generator component for Swashbuckle - a Swagger toolchain for ASP.NET Core",
   "authors": [ "Richard Morris" ],
 
   "packOptions": {

--- a/src/Swashbuckle.SwaggerUi/Swashbuckle.SwaggerUi.xproj
+++ b/src/Swashbuckle.SwaggerUi/Swashbuckle.SwaggerUi.xproj
@@ -4,17 +4,15 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>1c14cc40-1d89-4da9-a1d8-237fd8922371</ProjectGuid>
     <RootNamespace>Swashbuckle.SwaggerUi</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Swashbuckle.SwaggerUi/project.json
+++ b/src/Swashbuckle.SwaggerUi/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "version": "6.0.0-beta9",
-  "description": "Swagger UI component for Swashbuckle - a Swagger toolchain for AspNet Core",
+  "description": "Swagger UI component for Swashbuckle - a Swagger toolchain for ASP.NET Core",
   "authors": [ "Richard Morris" ],
 
   "buildOptions": {

--- a/src/Swashbuckle/Swashbuckle.nuspec
+++ b/src/Swashbuckle/Swashbuckle.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>Swashbuckle</id>
     <version>6.0.0-beta9</version>
-    <description>Swashbuckle - Swagger components for AspNet Core 1.0</description>
+    <description>Swashbuckle - Swagger components for ASP.NET Core 1.0</description>
     <authors>Richard Morris</authors>
     <tags>Swagger Documentation Discovery Help WebApi AspNet AspNetCore</tags>
     <projectUrl>https://github.com/domaindrivendev/Swashbuckle</projectUrl>
     <licenseUrl>https://github.com/domaindrivendev/Swashbuckle/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>Swagger components for next generation of Swashbuckle, targeting AspNet Core 1.0</summary>
+    <summary>Swagger components for next generation of Swashbuckle, targeting ASP.NET Core 1.0</summary>
     <owners>Richard Morris</owners>
     <dependencies>
       <group targetFramework=".NETStandard1.0">

--- a/test/Swashbuckle.IntegrationTests/Swashbuckle.IntegrationTests.xproj
+++ b/test/Swashbuckle.IntegrationTests/Swashbuckle.IntegrationTests.xproj
@@ -4,11 +4,11 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>fae3ae3a-e5b2-44b1-b402-fd96899c444b</ProjectGuid>
     <RootNamespace>Swashbuckle.IntegrationTests</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
@@ -17,5 +17,5 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Swashbuckle.SwaggerGen.Test/Swashbuckle.SwaggerGen.Test.xproj
+++ b/test/Swashbuckle.SwaggerGen.Test/Swashbuckle.SwaggerGen.Test.xproj
@@ -7,7 +7,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>6e1df729-097e-4baa-86e4-61bd8a6c5209</ProjectGuid>
     <RootNamespace>Swashbuckle.SwaggerGen</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -27,6 +27,6 @@
       <UserProperties project_1json__JSONSchema="" />
     </VisualStudio>
   </ProjectExtensions>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" />
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" />
 </Project>

--- a/test/Swashbuckle.SwaggerGen.Test/project.json
+++ b/test/Swashbuckle.SwaggerGen.Test/project.json
@@ -1,6 +1,7 @@
 {
   "buildOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "copyToOutput": "TestFixtures/XmlComments.xml"
   },
   "dependencies": {
     "xunit": "2.1.0",

--- a/test/WebSites/Basic/Basic.xproj
+++ b/test/WebSites/Basic/Basic.xproj
@@ -4,11 +4,11 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>b4c24875-7238-4408-aabf-1bb18e001312</ProjectGuid>
     <RootNamespace>Basic</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
@@ -19,5 +19,5 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/WebSites/Basic/Properties/launchSettings.json
+++ b/test/WebSites/Basic/Properties/launchSettings.json
@@ -13,13 +13,13 @@
       "launchBrowser": true,
       "launchUrl": "swagger/ui",
       "environmentVariables": {
-        "ASPNET_ENV": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "web": {
-      "commandName": "web",
+    "Basic": {
+      "commandName": "Project",
       "environmentVariables": {
-        "Hosting:Environment": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/test/WebSites/CustomizedUi/CustomizedUi.xproj
+++ b/test/WebSites/CustomizedUi/CustomizedUi.xproj
@@ -4,16 +4,16 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>55dce4fa-9d46-43cd-b19c-17215eee68e4</ProjectGuid>
     <RootNamespace>CustomizedUi</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
     <DevelopmentServerPort>7970</DevelopmentServerPort>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/WebSites/CustomizedUi/Properties/launchSettings.json
+++ b/test/WebSites/CustomizedUi/Properties/launchSettings.json
@@ -13,13 +13,13 @@
       "launchBrowser": true,
       "launchUrl": "swagger/ui",
       "environmentVariables": {
-        "ASPNET_ENV": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "web": {
-      "commandName": "web",
+    "CustomizedUi": {
+      "commandName": "Project",
       "environmentVariables": {
-        "ASPNET_ENV": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/test/WebSites/MultipleVersions/MultipleVersions.xproj
+++ b/test/WebSites/MultipleVersions/MultipleVersions.xproj
@@ -4,16 +4,16 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>b23c0c45-5b6f-4428-851b-766408517b13</ProjectGuid>
     <RootNamespace>MultipleVersions</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
     <DevelopmentServerPort>6605</DevelopmentServerPort>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/WebSites/MultipleVersions/Properties/launchSettings.json
+++ b/test/WebSites/MultipleVersions/Properties/launchSettings.json
@@ -13,13 +13,13 @@
       "launchBrowser": true,
       "launchUrl": "swagger/ui",
       "environmentVariables": {
-        "ASPNET_ENV": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "web": {
-      "commandName": "web",
+    "MultipleVersions": {
+      "commandName": "Project",
       "environmentVariables": {
-        "Hosting:Environment": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/test/WebSites/SecuritySchemes/Properties/launchSettings.json
+++ b/test/WebSites/SecuritySchemes/Properties/launchSettings.json
@@ -13,13 +13,13 @@
       "launchBrowser": true,
       "launchUrl": "swagger/ui",
       "environmentVariables": {
-        "ASPNET_ENV": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "web": {
-      "commandName": "web",
+    "SecuritySchemes": {
+      "commandName": "Project",
       "environmentVariables": {
-        "Hosting:Environment": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/test/WebSites/SecuritySchemes/SecuritySchemes.xproj
+++ b/test/WebSites/SecuritySchemes/SecuritySchemes.xproj
@@ -4,16 +4,16 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>44cd874e-a25e-466a-99ab-544bb900a33c</ProjectGuid>
     <RootNamespace>SecuritySchemes</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
     <DevelopmentServerPort>7462</DevelopmentServerPort>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/WebSites/VirtualDirectory/Properties/launchSettings.json
+++ b/test/WebSites/VirtualDirectory/Properties/launchSettings.json
@@ -13,13 +13,13 @@
       "launchBrowser": true,
       "launchUrl": "vdir/swagger/ui",
       "environmentVariables": {
-        "ASPNET_ENV": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "web": {
-      "commandName": "web",
+    "VirtualDirectory": {
+      "commandName": "Project",
       "environmentVariables": {
-        "ASPNET_ENV": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/test/WebSites/VirtualDirectory/VirtualDirectory.xproj
+++ b/test/WebSites/VirtualDirectory/VirtualDirectory.xproj
@@ -4,16 +4,16 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>28b55065-bfe6-4c82-afd3-6157408bbc37</ProjectGuid>
     <RootNamespace>VirtualDirectory</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
     <DevelopmentServerPort>4876</DevelopmentServerPort>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>


### PR DESCRIPTION
Hi Richard,

I made a few updates to the project-files and to the wording:

* AspNet Core -> ASP.NET Core in docs/nuget package descriptions (that's the official wording)
* Nightly NuGet feeds for ASP.NET and XUnit are no longer necessary (everything is on NuGet)
* DNX -> DotNet in xproj files (see https://github.com/aspnet/Templates/blob/dev/src/BaseTemplates/StarterWeb/StarterWeb.xproj )
* launchSettings.json fixed ( https://github.com/aspnet/Templates/blob/dev/src/BaseTemplates/StarterWeb/Properties/launchSettings.json )
* Tests: Copy TestFixtures/XmlComments.xml to output so that "dotnet test" works properly