### PR TITLE
Added support for DefaultValue data annontation attribute

### DIFF
--- a/src/Swashbuckle.SwaggerGen/Generator/SchemaExtensions.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SchemaExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using Newtonsoft.Json.Serialization;
@@ -16,6 +17,11 @@ namespace Swashbuckle.SwaggerGen.Generator
 
             foreach (var attribute in propInfo.GetCustomAttributes(false))
             {
+
+                var defaultValue = attribute as DefaultValueAttribute;
+                if (defaultValue != null)
+                    schema.Default = defaultValue.Value;
+
                 var regex = attribute as RegularExpressionAttribute;
                 if (regex != null)
                     schema.Pattern = regex.Pattern;

--- a/test/Swashbuckle.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
+++ b/test/Swashbuckle.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
@@ -198,6 +198,7 @@ namespace Swashbuckle.SwaggerGen.Generator
             Assert.Equal(3, schema.Properties["StringProperty2"].MaxLength);
             Assert.Equal("^[3-6]?\\d{12,15}$", schema.Properties["PatternProperty"].Pattern);
             Assert.Equal(new[] { "RangeProperty", "PatternProperty" }, schema.Required.ToArray());
+            Assert.Equal("DefaultValue", schema.Properties["DefaultValueProperty"].Default);
         }
 
         [Fact]

--- a/test/Swashbuckle.SwaggerGen.Test/TestFixtures/Types/DataAnnotatedType.cs
+++ b/test/Swashbuckle.SwaggerGen.Test/TestFixtures/Types/DataAnnotatedType.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 namespace Swashbuckle.SwaggerGen.TestFixtures
 {
@@ -17,5 +18,8 @@ namespace Swashbuckle.SwaggerGen.TestFixtures
         public string StringProperty2 { get; set; }
 
         public string OptionalProperty { get; set; }
+
+        [DefaultValue("DefaultValue")]
+        public string DefaultValueProperty { get; set; }
     }
 }


### PR DESCRIPTION
I had the need to populate with some some interesting data in all the properties of my Models, thought it would be useful for others as well
