### PR TITLE
Use MvcJsonOptions serializer formatting for swagger.json

### DIFF
--- a/src/Swashbuckle.Swagger/Application/SwaggerSerializerFactory.cs
+++ b/src/Swashbuckle.Swagger/Application/SwaggerSerializerFactory.cs
@@ -12,6 +12,7 @@ namespace Swashbuckle.Swagger.Application
             return new JsonSerializer
             {
                 NullValueHandling = NullValueHandling.Ignore,
+                Formatting = mvcJsonOptions.Value.SerializerSettings.Formatting,
                 ContractResolver = new SwaggerContractResolver(mvcJsonOptions.Value.SerializerSettings)
             };
         }


### PR DESCRIPTION
Enables user control over swagger.json document formatting. MvcJsonOptions preference is used when serializing swagger.json.