### PR TITLE
fix the the missed 'host' properites.

### DIFF
--- a/src/Swashbuckle.Swagger/Application/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.Swagger/Application/SwaggerMiddleware.cs
@@ -46,7 +46,7 @@ namespace Swashbuckle.Swagger.Application
                 ? "/"
                 : httpContext.Request.PathBase.ToString();
 
-            var swagger = _swaggerProvider.GetSwagger(documentName, null, basePath);
+            var swagger = _swaggerProvider.GetSwagger(documentName, httpContext.Request.Host.ToString(), basePath);
 
             // One last opportunity to modify the Swagger Document - this time with request context
             _documentFilter(swagger, httpContext.Request);


### PR DESCRIPTION
The host is missed, while invoking `GetSwagger`  in the middleware. (the original parameter just replaced by `null` value.)
One needs the `host` property while making swagger.json working well with the third-party tools, such as `Postman`. 
> if 'host' property missed, the imported entry in postman would generate the url like `http://foo/bar`, while urls like `http://foo.com:8888/foo/bar` with host was the correct one indeed.