### PR TITLE
Remove dependency on MVC in SwaggerUi

### DIFF
--- a/src/Swashbuckle.SwaggerUi/project.json
+++ b/src/Swashbuckle.SwaggerUi/project.json
@@ -29,9 +29,10 @@
   },
 
   "dependencies": {
-    "Microsoft.AspNetCore.Mvc.Core": "1.0.0",
+    "Microsoft.AspNetCore.Routing": "1.0.0",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0",
-    "Microsoft.Extensions.FileProviders.Embedded": "1.0.0"
+    "Microsoft.Extensions.FileProviders.Embedded": "1.0.0",
+    "Newtonsoft.Json": "9.0.1"
   },
 
   "frameworks": {


### PR DESCRIPTION
I'd like to use the SwaggerUi library outside of ASP.NET Core MVC. The library currently has a dependency on AspNetCore.Mvc.Core even though it doesn't need it.

This PR would remove this dependency and add back only the required dependencies.